### PR TITLE
Add basic vault webpage

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-segreto-caveau.it

--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+segreto-caveau.it

--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
-# secret-caveau
+# Secret Caveau
+
+This repository contains a simple web page that simulates unlocking a vault by entering three passwords. Each password field must match a specific word for the caveau (vault) to open.
+
+Open `index.html` in a browser to try it out. The page uses `styles.css` for basic styling and `script.js` for the password check logic.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Secret Caveau</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <h1>Accesso al Caveau</h1>
+  <div class="inputs">
+    <div>
+      <input type="password" id="pass1" placeholder="Password 1">
+      <span class="indicator" id="ind1"></span>
+    </div>
+    <div>
+      <input type="password" id="pass2" placeholder="Password 2">
+      <span class="indicator" id="ind2"></span>
+    </div>
+    <div>
+      <input type="password" id="pass3" placeholder="Password 3">
+      <span class="indicator" id="ind3"></span>
+    </div>
+  </div>
+  <button id="submitBtn">Invia</button>
+  <div id="message"></div>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,24 @@
+document.getElementById('submitBtn').addEventListener('click', function () {
+  const values = [
+    document.getElementById('pass1').value,
+    document.getElementById('pass2').value,
+    document.getElementById('pass3').value
+  ];
+  const targets = ['Giornata', 'Radio', 'Hollywood'];
+  let allCorrect = true;
+  values.forEach((val, idx) => {
+    const indicator = document.getElementById('ind' + (idx + 1));
+    if (val === targets[idx]) {
+      indicator.className = 'indicator success';
+    } else {
+      indicator.className = 'indicator error';
+      allCorrect = false;
+    }
+  });
+  const msg = document.getElementById('message');
+  if (allCorrect) {
+    msg.textContent = 'Caveau aperto';
+  } else {
+    msg.textContent = '';
+  }
+});

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,39 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 2rem;
+  text-align: center;
+}
+
+.inputs div {
+  margin-bottom: 1rem;
+}
+
+.indicator {
+  display: inline-block;
+  width: 20px;
+  height: 20px;
+  margin-left: 0.5rem;
+  vertical-align: middle;
+}
+
+.success {
+  background-color: orange;
+  border-radius: 50%;
+}
+
+.error {
+  background-color: red;
+  border-radius: 50%;
+}
+
+#message {
+  margin-top: 1.5rem;
+  font-size: 1.2rem;
+  color: green;
+  animation: fade 1s forwards;
+}
+
+@keyframes fade {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}


### PR DESCRIPTION
## Summary
- add simple web page for entering three passwords
- check inputs against the words "Giornata", "Radio" and "Hollywood"
- show visual feedback and success message when passwords are correct
- basic styling and documentation

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6868fa89eae08329b30129b500bdb4b1