### PR TITLE
Improve vault animation and style

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
-# secret-caveau
+# Secret Caveau
+
+This repository contains a simple web page that simulates unlocking a vault by entering three passwords. Each password field must match a specific word for the caveau (vault) to open.
+
+Open `index.html` in a browser to try it out. The page uses `styles.css` for a small cyberpunk look and `script.js` for the password check logic. When the passwords "Giornata", "Radio" and "Hollywood" are entered correctly the inputs disappear and an animated "Caveau aperto" message is shown.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Secret Caveau</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <div class="panel">
+    <h1>Accesso al Caveau</h1>
+    <div class="inputs">
+      <div>
+        <input type="password" id="pass1" placeholder="Password 1">
+        <span class="indicator" id="ind1"></span>
+      </div>
+      <div>
+        <input type="password" id="pass2" placeholder="Password 2">
+        <span class="indicator" id="ind2"></span>
+      </div>
+      <div>
+        <input type="password" id="pass3" placeholder="Password 3">
+        <span class="indicator" id="ind3"></span>
+      </div>
+    </div>
+    <button id="submitBtn">Invia</button>
+    <div id="message"></div>
+  </div>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,27 @@
+document.getElementById('submitBtn').addEventListener('click', function () {
+  const values = [
+    document.getElementById('pass1').value,
+    document.getElementById('pass2').value,
+    document.getElementById('pass3').value
+  ];
+  const targets = ['Giornata', 'Radio', 'Hollywood'];
+  let allCorrect = true;
+  values.forEach((val, idx) => {
+    const indicator = document.getElementById('ind' + (idx + 1));
+    if (val === targets[idx]) {
+      indicator.className = 'indicator success';
+    } else {
+      indicator.className = 'indicator error';
+      allCorrect = false;
+    }
+  });
+  const msg = document.getElementById('message');
+  if (allCorrect) {
+    msg.textContent = 'Caveau aperto';
+    document.querySelector('.inputs').style.display = 'none';
+    msg.classList.add('show');
+  } else {
+    msg.textContent = '';
+    msg.classList.remove('show');
+  }
+});

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,84 @@
+body {
+  font-family: 'Courier New', monospace;
+  margin: 2rem;
+  text-align: center;
+  background-color: #0d0d0d;
+  color: #c0fffc;
+}
+
+.panel {
+  display: inline-block;
+  padding: 2rem;
+  border: 2px solid #0ff;
+  box-shadow: 0 0 15px #0ff;
+}
+
+.inputs div {
+  margin-bottom: 1rem;
+}
+
+input[type="password"] {
+  padding: 0.5rem;
+  background: #222;
+  border: 1px solid #0ff;
+  color: #0ff;
+  box-shadow: 0 0 5px #0ff;
+}
+
+button {
+  padding: 0.6rem 1.2rem;
+  background: transparent;
+  border: 2px solid #0ff;
+  color: #0ff;
+  cursor: pointer;
+  font-weight: bold;
+  box-shadow: 0 0 8px #0ff;
+  transition: background 0.3s;
+}
+
+button:hover {
+  background: rgba(0, 255, 255, 0.2);
+}
+
+.indicator {
+  display: inline-block;
+  width: 20px;
+  height: 20px;
+  margin-left: 0.5rem;
+  vertical-align: middle;
+}
+
+.success {
+  background-color: #0f0;
+  border-radius: 50%;
+  box-shadow: 0 0 5px #0f0;
+}
+
+.error {
+  background-color: red;
+  border-radius: 50%;
+  box-shadow: 0 0 5px red;
+}
+
+#message {
+  display: none;
+  margin-top: 2rem;
+  font-size: 2rem;
+  color: #0f0;
+  text-shadow: 0 0 10px #0f0, 0 0 20px #0f0;
+  animation: fade 1s forwards, flicker 2s linear infinite;
+}
+
+#message.show {
+  display: block;
+}
+
+@keyframes flicker {
+  0%, 19%, 21%, 23%, 25%, 54%, 56%, 100% { opacity: 1; }
+  20%, 24%, 55% { opacity: 0.4; }
+}
+
+@keyframes fade {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}


### PR DESCRIPTION
## Summary
- tweak README to mention cyberpunk look and success message
- wrap inputs in a neon panel
- hide inputs and show animated message when passwords are correct
- switch success indicator to green and add cyberpunk-inspired styles

## Testing
- `git status --short`
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_6868fa89eae08329b30129b500bdb4b1