### PR TITLE
Replace lock with access icon and enhance reveal

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,14 +25,13 @@
       <p class="status-text">Sistema di contenzione criogenico bloccato</p>
     </section>
 
-    <div class="lock" id="lock" aria-hidden="true">
-      <div class="lock__shackle"></div>
-      <div class="lock__body">
-        <div class="lock__dial"></div>
-        <div class="lock__dial lock__dial--shadow"></div>
-      </div>
+    <div class="access-icon" id="accessIcon" aria-hidden="true">
+      <div class="access-icon__ring"></div>
+      <div class="access-icon__ring access-icon__ring--outer"></div>
+      <div class="access-icon__arrow"></div>
+      <div class="access-icon__pulse"></div>
     </div>
-    <span id="lockDesc" class="sr-only">Lucchetto chiuso</span>
+    <span id="accessDesc" class="sr-only">Accesso chiuso</span>
 
     <section class="panel__inputs">
       <h2 class="section-title">Inserire le quattro parole di attivazione</h2>
@@ -62,7 +61,7 @@
           <span class="sr-only" id="ind4-text">In attesa</span>
         </label>
       </div>
-      <button id="submitBtn" class="panel__button" aria-describedby="lockDesc">Avvia decrittazione</button>
+      <button id="submitBtn" class="panel__button" aria-describedby="accessDesc">Avvia decrittazione</button>
     </section>
 
     <section id="message" class="panel__message" aria-live="assertive"></section>

--- a/script.js
+++ b/script.js
@@ -24,14 +24,14 @@ document.getElementById('submitBtn').addEventListener('click', function () {
   });
 
   const msg = document.getElementById('message');
-  const lock = document.getElementById('lock');
-  const lockDesc = document.getElementById('lockDesc');
+  const accessIcon = document.getElementById('accessIcon');
+  const accessDesc = document.getElementById('accessDesc');
   const btn = document.getElementById('submitBtn');
   const secret = document.getElementById('secret');
 
   if (allCorrect) {
-    lock.classList.add('lock--open');
-    lockDesc.textContent = 'Lucchetto aperto';
+    accessIcon.classList.add('access-icon--active');
+    accessDesc.textContent = 'Accesso aperto';
     btn.classList.add('panel__button--disabled');
     btn.disabled = true;
     msg.className = 'panel__message panel__message--success show';
@@ -40,8 +40,8 @@ document.getElementById('submitBtn').addEventListener('click', function () {
     secret.classList.add('panel__secret--visible');
     document.querySelector('.panel__inputs').classList.add('panel__inputs--collapsed');
   } else {
-    lock.classList.remove('lock--open');
-    lockDesc.textContent = 'Lucchetto chiuso';
+    accessIcon.classList.remove('access-icon--active');
+    accessDesc.textContent = 'Accesso chiuso';
     btn.classList.remove('panel__button--disabled');
     btn.disabled = false;
     msg.className = 'panel__message panel__message--error show';

--- a/styles.css
+++ b/styles.css
@@ -153,80 +153,78 @@ body::after {
   color: var(--text-muted);
 }
 
-.lock {
+.access-icon {
   position: relative;
-  width: 130px;
+  width: 150px;
+  height: 150px;
   margin: 0 auto 1.5rem;
+  display: grid;
+  place-items: center;
   filter: drop-shadow(0 12px 24px rgba(0, 0, 0, 0.6));
   transition: transform 0.6s ease;
 }
 
-.lock__shackle {
+.access-icon__ring {
   position: absolute;
-  top: -70px;
-  left: 22px;
-  width: 86px;
-  height: 70px;
-  border-radius: 38px 38px 0 0;
-  border: 5px solid rgba(47, 243, 255, 0.8);
-  border-bottom: none;
-  background: radial-gradient(circle, rgba(47, 243, 255, 0.35), transparent);
-  transition: transform 0.8s ease;
-  transform-origin: center bottom;
-}
-
-.lock__body {
-  position: relative;
-  width: 100%;
+  width: 110px;
   height: 110px;
-  background: linear-gradient(160deg, rgba(8, 240, 170, 0.2), rgba(8, 16, 48, 0.9));
-  border-radius: 18px;
-  border: 4px solid rgba(47, 243, 255, 0.8);
-  overflow: hidden;
-}
-
-.lock__body::before {
-  content: "";
-  position: absolute;
-  inset: 14px;
-  border-radius: 12px;
-  border: 1px dashed rgba(143, 255, 0, 0.4);
-  animation: glitch 3s infinite;
-}
-
-.lock__dial,
-.lock__dial--shadow {
-  position: absolute;
-  inset: 50% auto auto 50%;
-  transform: translate(-50%, -50%);
-  width: 46px;
-  height: 46px;
   border-radius: 50%;
-  border: 3px solid rgba(47, 243, 255, 0.9);
-  background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.4), rgba(10, 18, 28, 0.9));
+  border: 3px solid rgba(47, 243, 255, 0.65);
+  box-shadow: 0 0 25px rgba(47, 243, 255, 0.4);
+  animation: rotate-slow 6s linear infinite;
 }
 
-.lock__dial--shadow {
-  filter: blur(8px);
-  opacity: 0.5;
+.access-icon__ring--outer {
+  width: 140px;
+  height: 140px;
+  border-color: rgba(142, 255, 0, 0.5);
+  animation-duration: 9s;
+  animation-direction: reverse;
 }
 
-.lock--open .lock__shackle {
-  transform: rotate(-35deg) translate(-12px, -10px);
+.access-icon__arrow {
+  width: 44px;
+  height: 44px;
+  clip-path: polygon(0 30%, 65% 30%, 65% 0, 100% 50%, 65% 100%, 65% 70%, 0 70%);
+  background: linear-gradient(135deg, rgba(142, 255, 0, 0.9), rgba(47, 243, 255, 0.5));
+  filter: drop-shadow(0 0 14px rgba(142, 255, 0, 0.6));
+  transform: translateX(-6px);
 }
 
-.lock--open {
-  transform: translateY(-8px) scale(1.02);
+.access-icon__pulse {
+  position: absolute;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: rgba(47, 243, 255, 0.85);
+  box-shadow: 0 0 22px rgba(47, 243, 255, 0.9);
+  animation: pulse-core 2.2s ease-in-out infinite;
+}
+
+.access-icon--active {
+  transform: translateY(-8px) scale(1.05);
+}
+
+.access-icon--active .access-icon__pulse {
+  animation: pulse-core 1.2s ease-in-out infinite;
+}
+
+.access-icon--active .access-icon__ring {
+  border-color: rgba(142, 255, 0, 0.9);
+  box-shadow: 0 0 30px rgba(142, 255, 0, 0.6);
 }
 
 .panel__inputs {
-  transition: transform 0.6s ease, opacity 0.6s ease;
+  transition: transform 0.6s ease, opacity 0.6s ease, max-height 0.6s ease;
+  max-height: 520px;
 }
 
 .panel__inputs--collapsed {
-  opacity: 0.2;
-  transform: scale(0.97);
+  opacity: 0;
+  transform: scale(0.7);
   pointer-events: none;
+  max-height: 0;
+  overflow: hidden;
 }
 
 .section-title {
@@ -359,13 +357,13 @@ input[type='password']:focus {
 }
 
 .panel__secret {
-  margin-top: 2.4rem;
+  margin-top: 1.2rem;
   padding: 1.8rem;
   border-radius: 16px;
   border: 1px solid rgba(142, 255, 0, 0.35);
   background: rgba(12, 20, 32, 0.8);
   box-shadow: inset 0 0 22px rgba(0, 0, 0, 0.65);
-  transform: translateY(30px);
+  transform: translateY(50px);
   opacity: 0;
   transition: transform 0.6s ease, opacity 0.6s ease;
 }
@@ -379,8 +377,9 @@ input[type='password']:focus {
 }
 
 .panel__secret--visible {
-  transform: translateY(0);
+  transform: translateY(-20px);
   opacity: 1;
+  animation: decrypt 1.6s ease-out;
 }
 
 .secret__label {
@@ -395,6 +394,22 @@ input[type='password']:focus {
   text-shadow: 0 0 20px rgba(142, 255, 0, 0.8);
   display: inline-block;
   margin-left: 1rem;
+  position: relative;
+  overflow: hidden;
+}
+
+.secret__code::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(120deg, transparent 0%, rgba(47, 243, 255, 0.8) 40%, transparent 70%);
+  transform: translateX(-100%);
+  animation: sweep 2.4s ease-in-out infinite;
+  opacity: 0;
+}
+
+.panel__secret--visible .secret__code::after {
+  opacity: 1;
 }
 
 .sr-only {
@@ -427,6 +442,56 @@ input[type='password']:focus {
   }
   100% {
     clip-path: inset(0 0 80% 0);
+  }
+}
+
+@keyframes rotate-slow {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes pulse-core {
+  0%,
+  100% {
+    transform: scale(0.7);
+    opacity: 0.4;
+  }
+  50% {
+    transform: scale(1.4);
+    opacity: 1;
+  }
+}
+
+@keyframes decrypt {
+  0% {
+    filter: blur(10px);
+    letter-spacing: 0.5em;
+    opacity: 0;
+  }
+  50% {
+    filter: blur(4px);
+    letter-spacing: 0.3em;
+    opacity: 1;
+  }
+  100% {
+    filter: blur(0);
+    letter-spacing: 0.18em;
+  }
+}
+
+@keyframes sweep {
+  0% {
+    transform: translateX(-150%);
+  }
+  40% {
+    transform: translateX(120%);
+  }
+  100% {
+    transform: translateX(120%);
   }
 }
 


### PR DESCRIPTION
## Summary
- replace the lock graphic with a new animated access icon and update related ARIA text
- collapse the password inputs after successful validation and lift the revealed code section higher on screen
- add decrypt-style animations for the secret code and icon pulse to emphasize the access event

## Testing
- no automated tests were run (not applicable)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f4152bae083299257b071ddc593c2)