### PR TITLE
Swap access glyph for scientist emblem and refresh console layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,50 +25,67 @@
       <p class="status-text">Sistema di contenzione criogenico bloccato</p>
     </section>
 
-    <div class="lock" id="lock" aria-hidden="true">
-      <div class="lock__shackle"></div>
-      <div class="lock__body">
-        <div class="lock__dial"></div>
-        <div class="lock__dial lock__dial--shadow"></div>
+    <div class="scientist-icon" id="scientistIcon" aria-hidden="true">
+      <div class="scientist-icon__halo"></div>
+      <div class="scientist-icon__glow"></div>
+      <div class="scientist-icon__body">
+        <div class="scientist-icon__head">
+          <div class="scientist-icon__hair"></div>
+          <div class="scientist-icon__glasses">
+            <span class="scientist-icon__lens"></span>
+            <span class="scientist-icon__bridge"></span>
+            <span class="scientist-icon__lens"></span>
+          </div>
+          <div class="scientist-icon__mask"></div>
+        </div>
+        <div class="scientist-icon__coat">
+          <span class="scientist-icon__lapel scientist-icon__lapel--left"></span>
+          <span class="scientist-icon__lapel scientist-icon__lapel--right"></span>
+          <span class="scientist-icon__badge"></span>
+        </div>
       </div>
     </div>
-    <span id="lockDesc" class="sr-only">Lucchetto chiuso</span>
+    <span id="accessDesc" class="sr-only">Ritratto del Dr. Vortex, accesso chiuso</span>
 
     <section class="panel__inputs">
       <h2 class="section-title">Inserire le quattro parole di attivazione</h2>
       <div class="inputs">
-        <label>
-          <span class="input-label">Sequenza Alfa</span>
-          <input type="password" id="pass1" placeholder="••••••" autocomplete="off">
-          <span class="indicator" id="ind1" aria-hidden="true"></span>
-          <span class="sr-only" id="ind1-text">In attesa</span>
-        </label>
-        <label>
-          <span class="input-label">Sequenza Beta</span>
-          <input type="password" id="pass2" placeholder="••••••" autocomplete="off">
-          <span class="indicator" id="ind2" aria-hidden="true"></span>
-          <span class="sr-only" id="ind2-text">In attesa</span>
-        </label>
-        <label>
-          <span class="input-label">Sequenza Gamma</span>
-          <input type="password" id="pass3" placeholder="••••••" autocomplete="off">
-          <span class="indicator" id="ind3" aria-hidden="true"></span>
-          <span class="sr-only" id="ind3-text">In attesa</span>
-        </label>
-        <label>
-          <span class="input-label">Sequenza Delta</span>
-          <input type="password" id="pass4" placeholder="••••••" autocomplete="off">
-          <span class="indicator" id="ind4" aria-hidden="true"></span>
-          <span class="sr-only" id="ind4-text">In attesa</span>
-        </label>
+        <div class="input-row">
+          <label>
+            <span class="input-label">Sequenza Alfa</span>
+            <input type="password" id="pass1" placeholder="••••••" autocomplete="off">
+            <span class="indicator" id="ind1" aria-hidden="true"></span>
+            <span class="sr-only" id="ind1-text">In attesa</span>
+          </label>
+          <label>
+            <span class="input-label">Sequenza Beta</span>
+            <input type="password" id="pass2" placeholder="••••••" autocomplete="off">
+            <span class="indicator" id="ind2" aria-hidden="true"></span>
+            <span class="sr-only" id="ind2-text">In attesa</span>
+          </label>
+        </div>
+        <div class="input-row">
+          <label>
+            <span class="input-label">Sequenza Gamma</span>
+            <input type="password" id="pass3" placeholder="••••••" autocomplete="off">
+            <span class="indicator" id="ind3" aria-hidden="true"></span>
+            <span class="sr-only" id="ind3-text">In attesa</span>
+          </label>
+          <label>
+            <span class="input-label">Sequenza Delta</span>
+            <input type="password" id="pass4" placeholder="••••••" autocomplete="off">
+            <span class="indicator" id="ind4" aria-hidden="true"></span>
+            <span class="sr-only" id="ind4-text">In attesa</span>
+          </label>
+        </div>
       </div>
-      <button id="submitBtn" class="panel__button" aria-describedby="lockDesc">Avvia decrittazione</button>
+      <button id="submitBtn" class="panel__button" aria-describedby="accessDesc">Avvia decrittazione</button>
     </section>
 
     <section id="message" class="panel__message" aria-live="assertive"></section>
     <section id="secret" class="panel__secret" aria-hidden="true">
       <h2>Codice Segreto</h2>
-      <p><span class="secret__label">Sequenza di sblocco:</span> <span class="secret__code">357</span></p>
+      <p><span class="secret__label">Codice di apertura dello scrigno:</span> <span class="secret__code">VX-42-ANT</span></p>
     </section>
   </main>
   <script src="script.js"></script>

--- a/script.js
+++ b/script.js
@@ -24,14 +24,14 @@ document.getElementById('submitBtn').addEventListener('click', function () {
   });
 
   const msg = document.getElementById('message');
-  const lock = document.getElementById('lock');
-  const lockDesc = document.getElementById('lockDesc');
+  const scientistIcon = document.getElementById('scientistIcon');
+  const accessDesc = document.getElementById('accessDesc');
   const btn = document.getElementById('submitBtn');
   const secret = document.getElementById('secret');
 
   if (allCorrect) {
-    lock.classList.add('lock--open');
-    lockDesc.textContent = 'Lucchetto aperto';
+    scientistIcon.classList.add('scientist-icon--active');
+    accessDesc.textContent = 'Ritratto del Dr. Vortex, accesso aperto';
     btn.classList.add('panel__button--disabled');
     btn.disabled = true;
     msg.className = 'panel__message panel__message--success show';
@@ -40,8 +40,8 @@ document.getElementById('submitBtn').addEventListener('click', function () {
     secret.classList.add('panel__secret--visible');
     document.querySelector('.panel__inputs').classList.add('panel__inputs--collapsed');
   } else {
-    lock.classList.remove('lock--open');
-    lockDesc.textContent = 'Lucchetto chiuso';
+    scientistIcon.classList.remove('scientist-icon--active');
+    accessDesc.textContent = 'Ritratto del Dr. Vortex, accesso chiuso';
     btn.classList.remove('panel__button--disabled');
     btn.disabled = false;
     msg.className = 'panel__message panel__message--error show';

--- a/styles.css
+++ b/styles.css
@@ -153,80 +153,178 @@ body::after {
   color: var(--text-muted);
 }
 
-.lock {
+.scientist-icon {
   position: relative;
-  width: 130px;
-  margin: 0 auto 1.5rem;
-  filter: drop-shadow(0 12px 24px rgba(0, 0, 0, 0.6));
-  transition: transform 0.6s ease;
+  width: clamp(180px, 24vw, 220px);
+  height: clamp(180px, 24vw, 220px);
+  margin: 0 auto 1.6rem;
+  display: grid;
+  place-items: center;
+  filter: drop-shadow(0 18px 32px rgba(0, 0, 0, 0.55));
+  transition: transform 0.6s ease, filter 0.6s ease;
 }
 
-.lock__shackle {
+.scientist-icon__halo {
   position: absolute;
-  top: -70px;
-  left: 22px;
-  width: 86px;
-  height: 70px;
-  border-radius: 38px 38px 0 0;
-  border: 5px solid rgba(47, 243, 255, 0.8);
-  border-bottom: none;
-  background: radial-gradient(circle, rgba(47, 243, 255, 0.35), transparent);
-  transition: transform 0.8s ease;
-  transform-origin: center bottom;
+  inset: 8%;
+  border-radius: 50%;
+  border: 2px dashed rgba(47, 243, 255, 0.65);
+  animation: rotate-slow 14s linear infinite;
+  mix-blend-mode: screen;
 }
 
-.lock__body {
+.scientist-icon__glow {
+  position: absolute;
+  width: 75%;
+  height: 75%;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(47, 243, 255, 0.35), transparent 70%);
+  filter: blur(0.5px);
+  animation: breathe 5s ease-in-out infinite;
+}
+
+.scientist-icon__body {
   position: relative;
-  width: 100%;
-  height: 110px;
-  background: linear-gradient(160deg, rgba(8, 240, 170, 0.2), rgba(8, 16, 48, 0.9));
-  border-radius: 18px;
-  border: 4px solid rgba(47, 243, 255, 0.8);
+  width: 64%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.scientist-icon__head {
+  position: relative;
+  width: 86px;
+  height: 86px;
+  border-radius: 38% 38% 42% 42%;
+  background: linear-gradient(160deg, rgba(240, 248, 255, 0.95), rgba(200, 220, 255, 0.75));
+  box-shadow: 0 12px 25px rgba(0, 0, 0, 0.4);
   overflow: hidden;
 }
 
-.lock__body::before {
-  content: "";
+.scientist-icon__hair {
   position: absolute;
-  inset: 14px;
+  top: -16px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 104px;
+  height: 58px;
+  background: radial-gradient(circle at 40% 50%, rgba(47, 243, 255, 0.2), transparent 65%),
+    linear-gradient(130deg, rgba(60, 80, 145, 0.9), rgba(25, 35, 70, 0.95));
+  border-radius: 48% 52% 35% 35%;
+  box-shadow: 0 8px 18px rgba(0, 0, 0, 0.4);
+}
+
+.scientist-icon__glasses {
+  position: absolute;
+  top: 38px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+}
+
+.scientist-icon__lens {
+  display: block;
+  width: 32px;
+  height: 26px;
+  border-radius: 40%;
+  border: 2px solid rgba(47, 243, 255, 0.75);
+  background: radial-gradient(circle at 30% 30%, rgba(47, 243, 255, 0.25), rgba(12, 18, 30, 0.95));
+  box-shadow: inset 0 0 12px rgba(47, 243, 255, 0.45);
+}
+
+.scientist-icon__bridge {
+  display: block;
+  width: 12px;
+  height: 10px;
+  border-radius: 40%;
+  border-top: 2px solid rgba(47, 243, 255, 0.75);
+  border-bottom: 2px solid rgba(47, 243, 255, 0.2);
+  background: linear-gradient(90deg, rgba(47, 243, 255, 0.2), rgba(142, 255, 0, 0.25));
+  transform: translateY(-4px);
+}
+
+.scientist-icon__mask {
+  position: absolute;
+  bottom: 6px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 68px;
+  height: 38px;
+  border-radius: 16px 16px 22px 22px;
+  background: linear-gradient(180deg, rgba(180, 245, 255, 0.9), rgba(140, 210, 255, 0.85));
+  box-shadow: inset 0 -6px 14px rgba(47, 243, 255, 0.25);
+}
+
+.scientist-icon__coat {
+  position: relative;
+  width: 120px;
+  height: 110px;
+  border-radius: 32px 32px 24px 24px;
+  background: linear-gradient(160deg, rgba(250, 250, 255, 0.95), rgba(220, 230, 255, 0.85));
+  box-shadow: inset 0 -14px 25px rgba(47, 243, 255, 0.18), 0 14px 28px rgba(0, 0, 0, 0.45);
+  overflow: hidden;
+}
+
+.scientist-icon__lapel {
+  position: absolute;
+  top: 26px;
+  width: 64px;
+  height: 68px;
+  background: linear-gradient(160deg, rgba(160, 200, 255, 0.35), rgba(230, 240, 255, 0.05));
   border-radius: 12px;
-  border: 1px dashed rgba(143, 255, 0, 0.4);
-  animation: glitch 3s infinite;
+  box-shadow: inset 0 0 18px rgba(47, 243, 255, 0.15);
 }
 
-.lock__dial,
-.lock__dial--shadow {
+.scientist-icon__lapel--left {
+  left: -6px;
+  transform: rotate(8deg);
+}
+
+.scientist-icon__lapel--right {
+  right: -6px;
+  transform: rotate(-8deg);
+}
+
+.scientist-icon__badge {
   position: absolute;
-  inset: 50% auto auto 50%;
-  transform: translate(-50%, -50%);
-  width: 46px;
-  height: 46px;
-  border-radius: 50%;
-  border: 3px solid rgba(47, 243, 255, 0.9);
-  background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.4), rgba(10, 18, 28, 0.9));
+  bottom: 16px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 54px;
+  height: 18px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, rgba(47, 243, 255, 0.6), rgba(142, 255, 0, 0.45));
+  box-shadow: 0 0 12px rgba(47, 243, 255, 0.6);
 }
 
-.lock__dial--shadow {
-  filter: blur(8px);
-  opacity: 0.5;
+.scientist-icon--active {
+  transform: translateY(-8px) scale(1.04);
+  filter: drop-shadow(0 20px 40px rgba(47, 243, 255, 0.35));
 }
 
-.lock--open .lock__shackle {
-  transform: rotate(-35deg) translate(-12px, -10px);
+.scientist-icon--active .scientist-icon__halo {
+  border-color: rgba(142, 255, 0, 0.8);
+  animation-duration: 9s;
 }
 
-.lock--open {
-  transform: translateY(-8px) scale(1.02);
+.scientist-icon--active .scientist-icon__glow {
+  background: radial-gradient(circle, rgba(142, 255, 0, 0.45), transparent 75%);
 }
 
 .panel__inputs {
-  transition: transform 0.6s ease, opacity 0.6s ease;
+  transition: transform 0.6s ease, opacity 0.6s ease, max-height 0.6s ease;
+  max-height: 520px;
 }
 
 .panel__inputs--collapsed {
-  opacity: 0.2;
-  transform: scale(0.97);
+  opacity: 0;
+  transform: scale(0.7);
   pointer-events: none;
+  max-height: 0;
+  overflow: hidden;
 }
 
 .section-title {
@@ -241,8 +339,21 @@ body::after {
 .inputs {
   display: grid;
   gap: 1.5rem;
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  width: 100%;
   margin-bottom: 2rem;
+}
+
+.input-row {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1.5rem;
+  width: 100%;
+  padding: 1.4rem clamp(1rem, 3vw, 1.8rem);
+  border-radius: 20px;
+  background: linear-gradient(135deg, rgba(47, 243, 255, 0.1), rgba(142, 255, 0, 0.05)),
+    rgba(6, 12, 24, 0.72);
+  border: 1px solid rgba(47, 243, 255, 0.32);
+  box-shadow: inset 0 0 18px rgba(0, 0, 0, 0.55);
 }
 
 label {
@@ -273,6 +384,11 @@ input[type='password'] {
   letter-spacing: 0.2em;
   text-transform: lowercase;
   box-shadow: inset 0 0 20px rgba(0, 0, 0, 0.6);
+}
+
+.input-row label {
+  width: 100%;
+  height: 100%;
 }
 
 input[type='password']:focus {
@@ -359,13 +475,13 @@ input[type='password']:focus {
 }
 
 .panel__secret {
-  margin-top: 2.4rem;
+  margin-top: 1.2rem;
   padding: 1.8rem;
   border-radius: 16px;
   border: 1px solid rgba(142, 255, 0, 0.35);
   background: rgba(12, 20, 32, 0.8);
   box-shadow: inset 0 0 22px rgba(0, 0, 0, 0.65);
-  transform: translateY(30px);
+  transform: translateY(50px);
   opacity: 0;
   transition: transform 0.6s ease, opacity 0.6s ease;
 }
@@ -379,8 +495,9 @@ input[type='password']:focus {
 }
 
 .panel__secret--visible {
-  transform: translateY(0);
+  transform: translateY(-20px);
   opacity: 1;
+  animation: decrypt 1.6s ease-out;
 }
 
 .secret__label {
@@ -395,6 +512,22 @@ input[type='password']:focus {
   text-shadow: 0 0 20px rgba(142, 255, 0, 0.8);
   display: inline-block;
   margin-left: 1rem;
+  position: relative;
+  overflow: hidden;
+}
+
+.secret__code::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(120deg, transparent 0%, rgba(47, 243, 255, 0.8) 40%, transparent 70%);
+  transform: translateX(-100%);
+  animation: sweep 2.4s ease-in-out infinite;
+  opacity: 0;
+}
+
+.panel__secret--visible .secret__code::after {
+  opacity: 1;
 }
 
 .sr-only {
@@ -427,6 +560,68 @@ input[type='password']:focus {
   }
   100% {
     clip-path: inset(0 0 80% 0);
+  }
+}
+
+@keyframes rotate-slow {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes pulse-core {
+  0%,
+  100% {
+    transform: scale(0.7);
+    opacity: 0.4;
+  }
+  50% {
+    transform: scale(1.4);
+    opacity: 1;
+  }
+}
+
+@keyframes decrypt {
+  0% {
+    filter: blur(10px);
+    letter-spacing: 0.5em;
+    opacity: 0;
+  }
+  50% {
+    filter: blur(4px);
+    letter-spacing: 0.3em;
+    opacity: 1;
+  }
+  100% {
+    filter: blur(0);
+    letter-spacing: 0.18em;
+  }
+}
+
+@keyframes breathe {
+  0%,
+  100% {
+    transform: scale(0.95);
+    opacity: 0.45;
+  }
+  50% {
+    transform: scale(1.05);
+    opacity: 0.85;
+  }
+}
+
+@keyframes sweep {
+  0% {
+    transform: translateX(-150%);
+  }
+  40% {
+    transform: translateX(120%);
+  }
+  100% {
+    transform: translateX(120%);
   }
 }
 
@@ -491,5 +686,10 @@ input[type='password']:focus {
 
   .secret__code {
     margin-left: 0.6rem;
+  }
+
+  .input-row {
+    grid-template-columns: 1fr;
+    padding: 1.1rem 1.2rem;
   }
 }


### PR DESCRIPTION
## Summary
- replace the initial access arrow with a stylized scientist badge and refresh the aria description
- restructure the password fields into two full-width rows and update the displayed unlock code for the antidote chest
- align the interaction script with the new scientist badge state changes and success messaging

## Testing
- no automated tests were run (not applicable)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f4152bae083299257b071ddc593c2)