### PR TITLE
Update access icon to antidote chest and adjust success text

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,7 +28,11 @@
     <div class="access-icon" id="accessIcon" aria-hidden="true">
       <div class="access-icon__ring"></div>
       <div class="access-icon__ring access-icon__ring--outer"></div>
-      <div class="access-icon__arrow"></div>
+      <div class="access-icon__chest">
+        <div class="access-icon__chest-lid"></div>
+        <div class="access-icon__chest-body"></div>
+        <div class="access-icon__chest-lock"></div>
+      </div>
       <div class="access-icon__pulse"></div>
     </div>
     <span id="accessDesc" class="sr-only">Accesso chiuso</span>

--- a/script.js
+++ b/script.js
@@ -35,7 +35,7 @@ document.getElementById('submitBtn').addEventListener('click', function () {
     btn.classList.add('panel__button--disabled');
     btn.disabled = true;
     msg.className = 'panel__message panel__message--success show';
-    msg.textContent = 'ACCESSO CONCESSO — Preparare il reattore!';
+    msg.textContent = "ACCESSO CONCESSO — Aprire lo scrigno dell'antidoto!";
     secret.setAttribute('aria-hidden', 'false');
     secret.classList.add('panel__secret--visible');
     document.querySelector('.panel__inputs').classList.add('panel__inputs--collapsed');

--- a/styles.css
+++ b/styles.css
@@ -182,13 +182,71 @@ body::after {
   animation-direction: reverse;
 }
 
-.access-icon__arrow {
-  width: 44px;
-  height: 44px;
-  clip-path: polygon(0 30%, 65% 30%, 65% 0, 100% 50%, 65% 100%, 65% 70%, 0 70%);
-  background: linear-gradient(135deg, rgba(142, 255, 0, 0.9), rgba(47, 243, 255, 0.5));
-  filter: drop-shadow(0 0 14px rgba(142, 255, 0, 0.6));
-  transform: translateX(-6px);
+.access-icon__chest {
+  position: relative;
+  width: 78px;
+  height: 60px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  filter: drop-shadow(0 0 18px rgba(142, 255, 0, 0.6));
+}
+
+.access-icon__chest-lid {
+  position: absolute;
+  top: 0;
+  width: 86%;
+  height: 24px;
+  border-radius: 12px 12px 6px 6px;
+  background: linear-gradient(135deg, rgba(142, 255, 0, 0.85), rgba(47, 243, 255, 0.4));
+  box-shadow: inset 0 -3px 6px rgba(0, 0, 0, 0.35);
+}
+
+.access-icon__chest-body {
+  position: absolute;
+  bottom: 0;
+  width: 100%;
+  height: 42px;
+  border-radius: 10px;
+  background: linear-gradient(135deg, rgba(19, 35, 58, 0.9), rgba(47, 243, 255, 0.35));
+  border: 2px solid rgba(47, 243, 255, 0.5);
+  box-shadow: inset 0 0 12px rgba(47, 243, 255, 0.35);
+}
+
+.access-icon__chest-body::before {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 70%;
+  height: 7px;
+  border-radius: 4px;
+  background: rgba(47, 243, 255, 0.35);
+  box-shadow: 0 0 10px rgba(47, 243, 255, 0.5);
+  transform: translate(-50%, -50%);
+}
+
+.access-icon__chest-lock {
+  position: absolute;
+  width: 18px;
+  height: 22px;
+  background: radial-gradient(circle at 50% 25%, rgba(142, 255, 0, 0.95), rgba(47, 243, 255, 0.5));
+  border-radius: 6px;
+  border: 1px solid rgba(19, 35, 58, 0.7);
+  box-shadow: 0 0 10px rgba(142, 255, 0, 0.6);
+}
+
+.access-icon__chest-lock::after {
+  content: "";
+  position: absolute;
+  top: 55%;
+  left: 50%;
+  width: 6px;
+  height: 8px;
+  border-radius: 3px;
+  background: rgba(19, 35, 58, 0.85);
+  transform: translate(-50%, -50%);
+  box-shadow: inset 0 0 4px rgba(0, 0, 0, 0.7);
 }
 
 .access-icon__pulse {


### PR DESCRIPTION
## Summary
- replace the access arrow graphic with a chest icon composed in CSS to reflect the antidote vault
- update the success notification to reference opening the antidote chest

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f565834d483298594efb463c7cb08)