### PR TITLE
Restore four-digit secret code

### DIFF
--- a/index.html
+++ b/index.html
@@ -70,8 +70,8 @@
 
     <section id="message" class="panel__message" aria-live="assertive"></section>
     <section id="secret" class="panel__secret" aria-hidden="true">
-      <h2>Codice Segreto</h2>
-      <p><span class="secret__label">Sequenza di sblocco:</span> <span class="secret__code">357</span></p>
+      <h2>Codice Segreto (4 cifre)</h2>
+      <p><span class="secret__label">Sequenza di sblocco:</span> <span class="secret__code">4753</span></p>
     </section>
   </main>
   <script src="script.js"></script>


### PR DESCRIPTION
## Summary
- update the secret code heading to specify a four-digit sequence
- change the revealed unlock code to a four-digit value

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915c9ed479883298ecec1a1732e686c)